### PR TITLE
INTGW-394 api name character limition fix

### DIFF
--- a/components/jaggery-apps/publisher/src/main/publisher/site/themes/wso2/templates/item-design/template.jag
+++ b/components/jaggery-apps/publisher/src/main/publisher/site/themes/wso2/templates/item-design/template.jag
@@ -139,7 +139,7 @@
 													<p id="name_help" class="hide"><%=i18n.localize("Display name to be shown in the API Store.")%></p>
 												</label>
 												<div class="col-sm-9">
-													<input type="text" class="form-control required validAPIName validateForwardSlashAtEnd validInput apiNameExists noSpace" maxlength="170" id="name" name="name" autofocus="autofocus" value=""/>
+													<input type="text" class="form-control required validAPIName validateForwardSlashAtEnd validInput apiNameExists noSpace" maxlength="50" id="name" name="name" autofocus="autofocus" value=""/>
 												</div>
 											</div>
 
@@ -154,14 +154,14 @@
 												<p id="context_help" class="hide"><%=i18n.localize("URI context path of the API (case sensitive).<br/> The supported formats are.. <br/> 1. /foo <br/> 2. /foo/bar <br/> 3. /foo/{version}/bar (case sensitive) - allows the version to be within the context")%></p>
 												</label>
 												<div class="col-sm-9">
-													<input type="text" class="form-control required validContextTemplate validateForwardSlashAtEnd validInput contextExists noSpace validTemplate validateVersionOnlyContext tenantContextExists validContext" id="context" name="context" onchange="getContextValue()"  onkeyup="updateContextPattern()"  />
+													<input type="text" class="form-control required validContextTemplate validateForwardSlashAtEnd validInput contextExists noSpace validTemplate validateVersionOnlyContext tenantContextExists validContext" id="context" maxlength="40" name="context" onchange="getContextValue()"  onkeyup="updateContextPattern()"  />
 												</div>
 											</div>
 
 											<div class="form-group">
 												<label class="col-sm-3 control-label" for="version"><%=i18n.localize("Version")%>:<span class="requiredAstrix">*</span></label>
 												<div class="col-sm-4">
-													<input type="text" class="form-control required validateAPIVersion validInput noSpace" placeholder="E.g., v1.0.0" id="version" name="version" onchange="getContextValue()" value="" onkeyup="updateContextPattern()"/>
+													<input type="text" class="form-control required validateAPIVersion validInput noSpace" placeholder="E.g., v1.0.0" maxlength="40" id="version" name="version" onchange="getContextValue()" value="" onkeyup="updateContextPattern()"/>
 												</div>
 											</div>
 											<% }else{ %>

--- a/components/jaggery-apps/store/src/main/store/site/themes/wso2/templates/subscription/subscribed-apis/template.jag
+++ b/components/jaggery-apps/store/src/main/store/site/themes/wso2/templates/subscription/subscribed-apis/template.jag
@@ -57,7 +57,7 @@
       </a>
 	    </div>
         <a title="<%= i18n.localize("API browse")%>" href="<%=jagg.urlTenanted("/site/pages/item-info.jag?name={{ apiName }}&version={{ apiVersion }}&provider={{ apiProvider }}")%>">
-        <h4>{{apiName}} - {{apiVersion}}</h4>
+        <h4 style="word-break: break-all;">{{apiName}} - {{apiVersion}}</h4>
         </a>
         <i class="fw fw-publish fw-1x"></i> {{status}}  	
 </script>

--- a/features/com.wso2telco.dep.hub.core.feature/src/main/resources/sql/mysql/dep_db.sql
+++ b/features/com.wso2telco.dep.hub.core.feature/src/main/resources/sql/mysql/dep_db.sql
@@ -348,7 +348,7 @@ CREATE TABLE IF NOT EXISTS `spendlimitdata` (
 CREATE TABLE IF NOT EXISTS `workflow_reference` (
   `workflow_ref_id` varchar(255) NOT NULL,
   `application_id` varchar(45) DEFAULT NULL,
-  `api_name` varchar(45) DEFAULT NULL,
+  `api_name` varchar(255) DEFAULT NULL,
   `api_version` varchar(45) DEFAULT NULL,
   `status` varchar(45) DEFAULT NULL,
   `service_endpoint` varchar(45) DEFAULT NULL,


### PR DESCRIPTION
Jira Link: [https://jira.wso2telco.com/jira/browse/INTGW-394]

- Limited the API name to 50 characters in publisher
-  Limited the context to 40 characters in publisher
-  Limited the version to 40 characters in publisher
-  workflow_reference api_name set to varchar(255)